### PR TITLE
Do not run df_country_ctn() if S_country is empty.

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -25,11 +25,17 @@ class Info extends \Df\Payment\Block\Info {
 			$this->siEx('iPay88 ID', $e->idE());
 			$this->si('Payment Option', $this->choiceT());
 			if ($e->isBankCard()) {
+				$country = $e->r('S_country');
+
+				if (!empty($country)) {
+					$country = df_country_ctn($country);
+				}
+
 				$this->si(['Card Number' => $e->r('CCNo'), 'Cardholder' => $e->r('CCName')]);
 				$this->siEx([
 					'Bank ID' =>  $e->r('BankMID')
 					,'Bank Name' => $e->r('S_bankname')
-					,'Bank Country' => df_country_ctn($e->r('S_country'))
+					,'Bank Country' => $country
 				]);
 			}
 		}


### PR DESCRIPTION
This pull request solves this issue - [https://github.com/mage2pro/ipay88/issues/11](https://github.com/mage2pro/ipay88/issues/11)

Sometimes the payment gateway was not receiving a country code via `S_country` in the `sales_payment_transaction table`. If that happens than Magento throws a fatal error when trying to run `df_country_ctn()` with an empty parameter.

This means that trying to print the invoice for the order fails with the following message:-
`[df_country_ctn] The argument «Неизвестный параметр» is rejected by the «Df\Zf\Validate\StringT\Iso2» validator. The diagnostic message: Система не смогла распознать значение «» типа «string» как 2-буквенный код страны под стандарту ISO 3166-1.`

You can test this by editing an orders `sales_payment_transaction` table, find the row that relates to the order and also has a type of `capture`. Look in the field `additional_information` for the data `S_country` and set it to empty.
Then go into the admin and try to print the invoice for the order.

